### PR TITLE
Duplicate properties support

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,10 @@ class computedDirective extends SchemaDirectiveVisitor {
 
       for (const property in updatedRoot) {
         if (Object.prototype.hasOwnProperty.call(updatedRoot, property)) {
-          value = value.replace(`$${property}`, updatedRoot[property]);
+          value = value.replace(
+            new RegExp(`\\$${property}`, 'g'),
+            updatedRoot[property]
+          );
         }
       }
 


### PR DESCRIPTION
With Regex now we can use duplicated properties. For example:
```
type User {
    firstName: String
    lastName: String
    fullName: String @computed(value: "$firstName $lastName $lastName")
  }
```
will return `$lastName` properly, which is a duplicated property.
Query : 
```
query {
  me{
    firstName
    lastName
    fullName
  }
}
```
Result:
```
{
  "data": {
    "me": {
      "firstName": "John",
      "lastName": "Doe",
      "fullName": "John Doe Doe"
    }
  }
}
```
